### PR TITLE
add observer verification

### DIFF
--- a/scripts/cmd/tuf/app/add-key.go
+++ b/scripts/cmd/tuf/app/add-key.go
@@ -85,18 +85,20 @@ func AddKeyCmd(ctx context.Context, directory string) error {
 		return err
 	}
 
-	// Add keys to each target file.
 	store := tuf.FileSystemStore(directory, nil)
-	root, err := getRootFromStore(store)
+
+	// Add keys to root
+	root, err := GetRootFromStore(store)
 	if err != nil {
 		return err
 	}
+	root.AddKey(keyAndAttestations.key)
+
+	// Add keys to each metadata file.
 	roles := []string{"root", "targets", "timestamp", "snapshot"}
 	for _, roleName := range roles {
 		role := root.Roles[roleName]
 		role.AddKeyIDs(keyAndAttestations.key.IDs())
-		root.AddKey(keyAndAttestations.key)
-
 	}
 	return setMeta(store, "root.json", root)
 }

--- a/scripts/cmd/tuf/app/init.go
+++ b/scripts/cmd/tuf/app/init.go
@@ -104,7 +104,7 @@ func InitCmd(directory string, targets targetsFlag) error {
 
 	// TODO: go-tuf does not support customizing root expiration. Hacked.
 	// We very hackishly by unmarshalling the JSON and do it manually.
-	root, err := getRootFromStore(store)
+	root, err := GetRootFromStore(store)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func createNewTimestamp(store tuf.LocalStore, expires time.Time) (*data.Timestam
 	return timestamp, nil
 }
 
-func getSignedMeta(store tuf.LocalStore, name string) (*data.Signed, error) {
+func GetSignedMeta(store tuf.LocalStore, name string) (*data.Signed, error) {
 	// Get name signed meta (name is of the form *.json)
 	meta, err := store.GetMeta()
 	if err != nil {
@@ -200,8 +200,8 @@ func getSignedMeta(store tuf.LocalStore, name string) (*data.Signed, error) {
 	return s, nil
 }
 
-func getRootFromStore(store tuf.LocalStore) (*data.Root, error) {
-	s, err := getSignedMeta(store, "root.json")
+func GetRootFromStore(store tuf.LocalStore) (*data.Root, error) {
+	s, err := GetSignedMeta(store, "root.json")
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/cmd/tuf/app/sign.go
+++ b/scripts/cmd/tuf/app/sign.go
@@ -62,9 +62,9 @@ func Sign() *ffcli.Command {
 	}
 }
 
-func createDb(store tuf.LocalStore) (*verify.DB, error) {
+func CreateDb(store tuf.LocalStore) (*verify.DB, error) {
 	db := verify.NewDB()
-	root, err := getRootFromStore(store)
+	root, err := GetRootFromStore(store)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func createDb(store tuf.LocalStore) (*verify.DB, error) {
 }
 
 func checkAndUpdateMetaForRole(store tuf.LocalStore, role []string) error {
-	db, err := createDb(store)
+	db, err := CreateDb(store)
 	if err != nil {
 		return fmt.Errorf("error creating verification database: %w", err)
 	}
@@ -94,7 +94,7 @@ func checkAndUpdateMetaForRole(store tuf.LocalStore, role []string) error {
 		case "snapshot":
 			// Check that root and target are signed correctly
 			for _, manifest := range []string{"root", "targets"} {
-				s, err := getSignedMeta(store, manifest+".json")
+				s, err := GetSignedMeta(store, manifest+".json")
 				if err != nil {
 					return err
 				}
@@ -108,7 +108,7 @@ func checkAndUpdateMetaForRole(store tuf.LocalStore, role []string) error {
 			}
 		case "timestamp":
 			// Check that snapshot is signed
-			s, err := getSignedMeta(store, "snapshot.json")
+			s, err := GetSignedMeta(store, "snapshot.json")
 			if err != nil {
 				return err
 			}
@@ -181,7 +181,7 @@ func updateSnapshot(store tuf.LocalStore) error {
 }
 
 func updateTimestamp(store tuf.LocalStore) error {
-	s, err := getSignedMeta(store, "timestamp.json")
+	s, err := GetSignedMeta(store, "timestamp.json")
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func updateTimestamp(store tuf.LocalStore) error {
 
 func SignMeta(ctx context.Context, store tuf.LocalStore, name string, signer signature.Signer, key *data.Key) error {
 	fmt.Printf("Signing metadata for %s... \n", name)
-	s, err := getSignedMeta(store, name)
+	s, err := GetSignedMeta(store, name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

observers can run verification during the signing to get outputs like 

```
$ ./verify --root piv-attestation-ca.pem --key-directory $REPO/keys --repository $REPO
verified key 14833186

Verifying root...
	Contains 1/3 valid signatures

Verifying snapshot...
	Error verifying: tuf: data has no signatures

Verifying targets...
	Contains 1/3 valid signatures

Verifying timestamp...
	Error verifying: tuf: data has no signatures
```